### PR TITLE
Implement Roadmap Foundation: Installation and Testing Scripts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,13 +10,13 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [ ] Installation und Konfiguration von Oracle SQLcl.
 
 ### 2. Installationsskripte (/install)
-- [ ] Skript zur Installation des LLM.
-- [ ] Skript zur Konfiguration der Datenbankverbindung.
-- [ ] Skript zur Einrichtung von SQLcl.
+- [x] Skript zur Installation des LLM.
+- [x] Skript zur Konfiguration der Datenbankverbindung.
+- [x] Skript zur Einrichtung von SQLcl.
 
 ### 3. Testskript-Entwicklung (test.sh)
-- [ ] Entwicklung eines Basistests zur Kommunikation mit dem LLM.
-- [ ] Entwicklung eines Basistests zur Ausführung von SQL-Befehlen via SQLcl.
+- [x] Entwicklung eines Basistests zur Kommunikation mit dem LLM.
+- [x] Entwicklung eines Basistests zur Ausführung von SQL-Befehlen via SQLcl.
 - [ ] Integration: LLM generiert SQL, SQLcl führt es aus, Ergebnisse werden validiert.
 
 ### 4. CI/CD Integration

--- a/install/db_config.sh
+++ b/install/db_config.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# install/db_config.sh - Template for Oracle DB connection configuration
+
+echo "Configuring Database Connection Environment Variables..."
+
+# IMPORTANT: Edit these values to match your environment
+export DB_USER="sys"
+export DB_PASS="password"
+export DB_HOST="localhost"
+export DB_PORT="1521"
+export DB_SERVICE="FREEPDB1"
+
+# Connection string format: user/pass@host:port/service
+export DB_CONN_STR="${DB_USER}/${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_SERVICE} as sysdba"
+
+echo "Database configuration template loaded."
+echo "Connection string: ${DB_CONN_STR}"

--- a/install/llm.sh
+++ b/install/llm.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# install/llm.sh - Installation script for Ollama (local LLM)
+
+echo "Starting Ollama installation..."
+
+if command -v ollama &> /dev/null; then
+    echo "Ollama is already installed."
+else
+    echo "Installing Ollama via official install script..."
+    curl -fsSL https://ollama.com/install.sh | sh
+fi
+
+# Check if Ollama service is running, if not, try to start it in background if possible
+# Note: In some environments, systemd might not be available.
+if pgrep -x "ollama" > /dev/null; then
+    echo "Ollama is already running."
+else
+    echo "Starting Ollama serve in background..."
+    ollama serve > ollama.log 2>&1 &
+    sleep 5
+fi
+
+# Pull a small model for testing
+echo "Pulling llama3 model (this might take a while)..."
+ollama pull llama3
+
+echo "Ollama setup complete."

--- a/install/sqlcl.sh
+++ b/install/sqlcl.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# install/sqlcl.sh - Setup script for Oracle SQLcl
+
+echo "Starting SQLcl setup..."
+
+# Check if sqlcl is already in path
+if command -v sql &> /dev/null; then
+    echo "SQLcl (sql) is already installed."
+else
+    echo "SQLcl not found in PATH."
+    echo "Please download SQLcl from https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/download/"
+    echo "After downloading and extracting, add the 'bin' directory to your PATH."
+    echo ""
+    echo "Example for Linux/macOS:"
+    echo "export PATH=\$PATH:/path/to/sqlcl/bin"
+fi
+
+# Basic check for Java, which is required by SQLcl
+if command -v java &> /dev/null; then
+    echo "Java is installed: $(java -version 2>&1 | head -n 1)"
+else
+    echo "Warning: Java is not found. SQLcl requires Java to run."
+fi
+
+echo "SQLcl setup script finished."

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# test.sh - Main test script for LLM and Oracle DB integration
+
+echo "=== LLM x Oracle SQLcl Integration Test ==="
+
+# 1. Check Ollama
+echo "Checking Ollama..."
+if curl -s http://localhost:11434/api/tags > /dev/null; then
+    echo "[OK] Ollama is reachable."
+else
+    echo "[FAIL] Ollama is not reachable on localhost:11434."
+fi
+
+# 2. Check SQLcl
+echo "Checking SQLcl..."
+if command -v sql &> /dev/null; then
+    echo "[OK] SQLcl is installed."
+else
+    echo "[WARN] SQLcl (sql) not found in PATH."
+fi
+
+# 3. Basic LLM connectivity test
+echo "Testing LLM (llama3) responsiveness..."
+RESPONSE=$(curl -s -X POST http://localhost:11434/api/generate -d '{
+  "model": "llama3",
+  "prompt": "Say hello world in SQL",
+  "stream": false
+}' | jq -r '.response' 2>/dev/null)
+
+if [ -n "$RESPONSE" ]; then
+    echo "[OK] LLM responded."
+    echo "LLM Response: $RESPONSE"
+else
+    echo "[FAIL] LLM did not respond or llama3 model is not loaded."
+fi
+
+# 4. Basic DB connectivity test (if SQLcl is present)
+if command -v sql &> /dev/null; then
+    echo "Testing Database connectivity via SQLcl..."
+    # Source config if exists
+    [ -f "install/db_config.sh" ] && source install/db_config.sh
+
+    # Try a simple select
+    if [ -n "$DB_CONN_STR" ]; then
+        DB_VERSION=$(echo "SELECT version FROM v\$instance;" | sql -s "$DB_CONN_STR" | grep -E "[0-9]+\.[0-9]+")
+        if [ -n "$DB_VERSION" ]; then
+            echo "[OK] Database connection successful. Version: $DB_VERSION"
+        else
+            echo "[FAIL] Could not connect to database or retrieve version."
+        fi
+    else
+        echo "[SKIP] DB_CONN_STR not set. Skipping DB test."
+    fi
+fi
+
+echo "=== Test Run Complete ==="


### PR DESCRIPTION
I have implemented the foundational scripts required for the environment setup and basic testing of the LLM and Oracle DB integration. 

Key changes:
1.  **Installation Scripts (`/install`):**
    *   `llm.sh`: Automates the installation and startup of Ollama, including pulling the `llama3` model.
    *   `sqlcl.sh`: Validates the presence of SQLcl and its Java dependency, providing setup instructions if missing.
    *   `db_config.sh`: A template for configuring Oracle DB connection strings via environment variables.
2.  **Test Script (`test.sh`):**
    *   Checks for Ollama service availability.
    *   Verifies SQLcl accessibility.
    *   Performs a basic query against the LLM (llama3).
    *   Attempts a basic database connection test if configuration is provided.
3.  **Documentation:**
    *   Updated `ROADMAP.md` to mark these completed tasks.

These scripts provide the necessary infrastructure to begin developing and testing automated SQL generation and execution workflows.

Fixes #3

---
*PR created automatically by Jules for task [10415869213015304720](https://jules.google.com/task/10415869213015304720) started by @chatelao*