### PR TITLE
Split GH workflow to install everything and then run tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, master ]
 
 jobs:
-  test:
+  install-and-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -16,7 +16,13 @@ jobs:
     - name: Set up Environment
       run: |
         sudo apt-get update
-        sudo apt-get install -y jq curl
+        sudo apt-get install -y jq curl unzip
+
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '17'
 
     - name: Check Scripts Syntax
       run: |
@@ -25,10 +31,48 @@ jobs:
         bash -n install/sqlcl.sh
         bash -n install/db_config.sh
 
-    - name: Run Test Script (Dry Run/Connectivity Check)
+    - name: Install SQLcl
+      run: bash install/sqlcl.sh
+
+    - name: Start Services (Database and Ollama)
       run: |
-        # This will mostly fail or skip in a standard GitHub Runner as Ollama/SQLcl/DB are missing.
-        # But it tests the script's ability to handle missing dependencies gracefully and generate a report.
+        docker-compose up -d
+        # We start Ollama via docker-compose as defined in the project,
+        # but the install/llm.sh might also be used for local setup.
+        # For CI, we'll rely on docker-compose for the service.
+
+    - name: Wait for Oracle Database
+      run: |
+        echo "Waiting for Oracle Database to be healthy..."
+        # The docker-compose has a healthcheck, we can wait for it.
+        MAX_RETRIES=60
+        COUNT=0
+        until [ "$(docker inspect --format='{{.State.Health.Status}}' oracle-db)" == "healthy" ]; do
+            sleep 10
+            COUNT=$((COUNT + 1))
+            if [ $COUNT -ge $MAX_RETRIES ]; then
+                echo "Error: Oracle Database failed to become healthy."
+                docker logs oracle-db
+                exit 1
+            fi
+            echo "Still waiting... ($((COUNT * 10))s)"
+        done
+        echo "Oracle Database is healthy."
+
+    - name: Pull LLM Model
+      run: |
+        # Use the local ollama command to talk to the container
+        # First install ollama cli if not present (install/llm.sh does this)
+        # But we need it to point to the docker container if we run it from host
+        # Actually, it's easier to just run it inside the container or via curl
+        docker exec ollama ollama pull llama3
+
+    - name: Run Test Script
+      env:
+        DB_CONN_STR: "system/password@localhost:1521/FREEPDB1"
+      run: |
+        # Ensure we can connect to the DB from the host
+        # The docker-compose maps 1521:1521
         bash test.sh
 
     - name: Upload Test Report to Summary

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Start Services (Database and Ollama)
       run: |
-        docker-compose up -d
+        docker compose up -d
         # We start Ollama via docker-compose as defined in the project,
         # but the install/llm.sh might also be used for local setup.
         # For CI, we'll rely on docker-compose for the service.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,9 +10,9 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [x] Installation und Konfiguration von Oracle SQLcl.
 
 ### 2. Installationsskripte (/install)
-- [x] Skript zur Installation des LLM.
+- [x] Skript zur Installation des LLM (verbessert für CI).
 - [x] Skript zur Konfiguration der Datenbankverbindung.
-- [x] Skript zur Einrichtung von SQLcl.
+- [x] Skript zur Einrichtung von SQLcl (automatisiert für CI).
 
 ### 3. Testskript-Entwicklung (test.sh)
 - [x] Entwicklung eines Basistests zur Kommunikation mit dem LLM.
@@ -21,8 +21,8 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 
 ### 4. CI/CD Integration
 - [x] Erstellung eines GitHub Action Workflows.
-- [x] Automatisierte Testläufe bei jedem Push.
+- [x] Automatisierte Testläufe bei jedem Push (verbessert: Services via Docker, automatisierte Installation).
 - [x] Berichterstattung über Testergebnisse (generiert `test-report.md` und zeigt es in GitHub Summaries an).
 
 ## Fortschrittsbewertung
-Der Fortschritt wird durch das Bestehen des `test.sh` Skripts in der CI/CD-Pipeline gemessen.
+Der Fortschritt wird durch das Bestehen des `test.sh` Skripts in der CI/CD-Pipeline gemessen. Die Pipeline wurde optimiert, um die notwendige Infrastruktur (Datenbank und LLM) während des Laufs bereitzustellen.

--- a/install/llm.sh
+++ b/install/llm.sh
@@ -11,17 +11,30 @@ else
 fi
 
 # Check if Ollama service is running, if not, try to start it in background if possible
-# Note: In some environments, systemd might not be available.
 if pgrep -x "ollama" > /dev/null; then
     echo "Ollama is already running."
 else
     echo "Starting Ollama serve in background..."
     ollama serve > ollama.log 2>&1 &
-    sleep 5
+
+    # Wait for Ollama to be ready
+    echo "Waiting for Ollama service to be ready..."
+    MAX_RETRIES=30
+    COUNT=0
+    while ! curl -s http://localhost:11434/api/tags > /dev/null; do
+        sleep 2
+        COUNT=$((COUNT + 1))
+        if [ $COUNT -ge $MAX_RETRIES ]; then
+            echo "Error: Ollama service failed to start after 60 seconds."
+            exit 1
+        fi
+    done
+    echo "Ollama service is ready."
 fi
 
 # Pull a small model for testing
-echo "Pulling llama3 model (this might take a while)..."
-ollama pull llama3
+LLM_MODEL=${LLM_MODEL:-llama3}
+echo "Pulling $LLM_MODEL model (this might take a while)..."
+ollama pull "$LLM_MODEL"
 
 echo "Ollama setup complete."

--- a/install/sqlcl.sh
+++ b/install/sqlcl.sh
@@ -3,23 +3,46 @@
 
 echo "Starting SQLcl setup..."
 
-# Check if sqlcl is already in path
-if command -v sql &> /dev/null; then
-    echo "SQLcl (sql) is already installed."
-else
-    echo "SQLcl not found in PATH."
-    echo "Please download SQLcl from https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/download/"
-    echo "After downloading and extracting, add the 'bin' directory to your PATH."
-    echo ""
-    echo "Example for Linux/macOS:"
-    echo "export PATH=\$PATH:/path/to/sqlcl/bin"
-fi
-
 # Basic check for Java, which is required by SQLcl
 if command -v java &> /dev/null; then
     echo "Java is installed: $(java -version 2>&1 | head -n 1)"
 else
-    echo "Warning: Java is not found. SQLcl requires Java to run."
+    echo "Error: Java is not found. SQLcl requires Java to run."
+    # In CI we might want to install it, but usually the runner has it or we install it in the workflow
+fi
+
+# Check if sqlcl is already in path
+if command -v sql &> /dev/null; then
+    echo "SQLcl (sql) is already installed."
+else
+    echo "SQLcl not found in PATH. Attempting to install..."
+
+    SQLCL_DIR="$HOME/sqlcl"
+    if [ ! -d "$SQLCL_DIR" ]; then
+        mkdir -p "$SQLCL_DIR"
+        echo "Downloading SQLcl..."
+        curl -L https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-latest.zip -o sqlcl-latest.zip
+        echo "Unzipping SQLcl..."
+        unzip -q sqlcl-latest.zip -d "$SQLCL_DIR"
+        rm sqlcl-latest.zip
+    fi
+
+    # Find the bin directory
+    SQLCL_BIN=$(find "$SQLCL_DIR" -name "sql" -type f | grep "/bin/sql" | head -n 1)
+    if [ -n "$SQLCL_BIN" ]; then
+        SQLCL_BIN_DIR=$(dirname "$SQLCL_BIN")
+        echo "SQLcl installed to $SQLCL_BIN_DIR"
+        echo "Add this to your PATH: export PATH=\$PATH:$SQLCL_BIN_DIR"
+
+        # If in GitHub Actions, add to GITHUB_PATH
+        if [ -n "$GITHUB_PATH" ]; then
+            echo "$SQLCL_BIN_DIR" >> "$GITHUB_PATH"
+            echo "Added $SQLCL_BIN_DIR to GITHUB_PATH"
+        fi
+    else
+        echo "Error: Could not find sql binary after installation."
+        exit 1
+    fi
 fi
 
 echo "SQLcl setup script finished."


### PR DESCRIPTION
I have split the GitHub Actions workflow into a more robust "install and test" structure. Key changes include:
- **`install/sqlcl.sh`**: Now automatically downloads and installs SQLcl if it's not found, and correctly handles `GITHUB_PATH` in CI.
- **`install/llm.sh`**: Includes a wait loop to ensure the Ollama service is responsive before pulling models.
- **`.github/workflows/test-integration.yml`**: Now uses `docker-compose` to start services, waits for the database to be healthy, installs Java and SQLcl, and pulls the required LLM model before running `test.sh`.
- **`ROADMAP.md`**: Updated to reflect the completed automation of the CI/CD environment.

Fixes #9

---
*PR created automatically by Jules for task [5228851600034941801](https://jules.google.com/task/5228851600034941801) started by @chatelao*