### PR TITLE
Fix DB connection error and implement CI caching for Docker/LLM

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -13,6 +13,31 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Cache SQLcl
+      uses: actions/cache@v4
+      with:
+        path: ~/sqlcl
+        key: ${{ runner.os }}-sqlcl-latest
+
+    - name: Cache Ollama Models
+      uses: actions/cache@v4
+      with:
+        path: ./ollama_data
+        key: ${{ runner.os }}-ollama-llama3
+
+    - name: Cache Docker Images
+      id: cache-docker-images
+      uses: actions/cache@v4
+      with:
+        path: /tmp/docker-images
+        key: ${{ runner.os }}-docker-images-${{ hashFiles('docker-compose.yml') }}
+
+    - name: Load Docker Images
+      run: |
+        if [ -f /tmp/docker-images/images.tar ]; then
+          docker load -i /tmp/docker-images/images.tar
+        fi
+
     - name: Set up Environment
       run: |
         sudo apt-get update
@@ -65,7 +90,14 @@ jobs:
         # First install ollama cli if not present (install/llm.sh does this)
         # But we need it to point to the docker container if we run it from host
         # Actually, it's easier to just run it inside the container or via curl
-        docker exec ollama ollama pull llama3
+
+        # Check if the model already exists to avoid redundant pull
+        if ! docker exec ollama ollama list | grep -q "llama3"; then
+          echo "llama3 model not found in cache. Pulling..."
+          docker exec ollama ollama pull llama3
+        else
+          echo "llama3 model found in cache. Skipping pull."
+        fi
 
     - name: Run Test Script
       env:
@@ -74,6 +106,12 @@ jobs:
         # Ensure we can connect to the DB from the host
         # The docker compose maps 1521:1521
         bash test.sh
+
+    - name: Save Docker Images
+      if: steps.cache-docker-images.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p /tmp/docker-images
+        docker save container-registry.oracle.com/database/free:latest ollama/ollama:latest -o /tmp/docker-images/images.tar
 
     - name: Upload Test Report to Summary
       if: always()

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,6 +23,8 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [x] Erstellung eines GitHub Action Workflows.
 - [x] Automatisierte Testläufe bei jedem Push (verbessert: Services via Docker, automatisierte Installation).
 - [x] Berichterstattung über Testergebnisse (generiert `test-report.md` und zeigt es in GitHub Summaries an).
+- [x] Optimierung der CI-Laufzeit durch Caching (Docker Images, SQLcl, LLM Modelle).
+- [x] Fehlerbehebung bei der Datenbankverbindung (Umstellung auf `system` User).
 
 ## Fortschrittsbewertung
 Der Fortschritt wird durch das Bestehen des `test.sh` Skripts in der CI/CD-Pipeline gemessen. Die Pipeline wurde optimiert, um die notwendige Infrastruktur (Datenbank und LLM) während des Laufs bereitzustellen.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,4 @@ services:
     ports:
       - "11434:11434"
     volumes:
-      - ollama_data:/root/.ollama
-
-volumes:
-  ollama_data:
+      - ./ollama_data:/root/.ollama

--- a/install/db_config.sh
+++ b/install/db_config.sh
@@ -4,14 +4,14 @@
 echo "Configuring Database Connection Environment Variables..."
 
 # IMPORTANT: Edit these values to match your environment
-export DB_USER="sys"
+export DB_USER="system"
 export DB_PASS="password"
 export DB_HOST="localhost"
 export DB_PORT="1521"
 export DB_SERVICE="FREEPDB1"
 
 # Connection string format: user/pass@host:port/service
-export DB_CONN_STR="${DB_USER}/${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_SERVICE} as sysdba"
+export DB_CONN_STR="${DB_USER}/${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_SERVICE}"
 
 echo "Database configuration template loaded."
 echo "Connection string: ${DB_CONN_STR}"

--- a/install/sqlcl.sh
+++ b/install/sqlcl.sh
@@ -38,8 +38,13 @@ else
     SQLCL_BIN=$(find "$SQLCL_DIR" -name "sql" -type f | grep "/bin/sql" | head -n 1)
     if [ -n "$SQLCL_BIN" ]; then
         SQLCL_BIN_DIR=$(dirname "$SQLCL_BIN")
-        echo "SQLcl installed to $SQLCL_BIN_DIR"
-        echo "Add this to your PATH: export PATH=\$PATH:$SQLCL_BIN_DIR"
+        echo "SQLcl found at $SQLCL_BIN_DIR"
+
+        # If not already in PATH, add it
+        if [[ ":$PATH:" != *":$SQLCL_BIN_DIR:"* ]]; then
+            echo "Adding $SQLCL_BIN_DIR to PATH"
+            export PATH="$PATH:$SQLCL_BIN_DIR"
+        fi
 
         # If in GitHub Actions, add to GITHUB_PATH
         if [ -n "$GITHUB_PATH" ]; then
@@ -48,7 +53,7 @@ else
         fi
         IS_SQLCL=true
     else
-        echo "Error: Could not find sql binary after installation."
+        echo "Error: Could not find sql binary in $SQLCL_DIR."
         exit 1
     fi
 fi

--- a/test.sh
+++ b/test.sh
@@ -62,8 +62,9 @@ if command -v sql &> /dev/null; then
 
     # Try a simple select
     if [ -n "$DB_CONN_STR" ]; then
-        DB_VERSION=$(echo "SELECT version FROM v\$instance;" | sql -s "$DB_CONN_STR" | grep -E "[0-9]+\.[0-9]+")
-        if [ -n "$DB_VERSION" ]; then
+        # Use pipefail to catch sql errors
+        DB_VERSION=$(set -o pipefail; echo "SELECT version FROM v\$instance;" | sql -s "$DB_CONN_STR" | grep -E "[0-9]+\.[0-9]+")
+        if [ $? -eq 0 ] && [ -n "$DB_VERSION" ]; then
             echo "[OK] Database connection successful. Version: $DB_VERSION"
             log_result "DB Connectivity" "✅ OK" "Database version: $DB_VERSION"
         else
@@ -96,13 +97,18 @@ if command -v sql &> /dev/null && [ -n "$DB_CONN_STR" ]; then
 
         if [ -n "$CLEAN_SQL" ]; then
             echo "Executing LLM generated SQL: $CLEAN_SQL"
-            SQL_RESULT=$(echo "$CLEAN_SQL" | sql -s "$DB_CONN_STR" | grep -v "connected")
-            if [ $? -eq 0 ]; then
+            # Capture output and exit code
+            SQL_OUTPUT=$(echo "$CLEAN_SQL" | sql -s "$DB_CONN_STR" 2>&1)
+            SQL_EXIT_CODE=$?
+            CLEAN_RESULT=$(echo "$SQL_OUTPUT" | grep -v "connected" | grep -v "USER          =" | grep -v "URL           =" | grep -v "Error Message =" | xargs)
+
+            if [ $SQL_EXIT_CODE -eq 0 ] && [[ ! "$SQL_OUTPUT" =~ "ORA-" ]]; then
                 echo "[OK] Integration test successful."
-                echo "Result: $SQL_RESULT"
+                echo "Result: $CLEAN_RESULT"
                 log_result "Integration Test" "✅ OK" "SQL executed successfully"
             else
                 echo "[FAIL] Failed to execute generated SQL."
+                echo "Error: $SQL_OUTPUT"
                 log_result "Integration Test" "❌ FAIL" "Failed to execute generated SQL"
             fi
         else


### PR DESCRIPTION
This change addresses the database connection failure (ORA-01017) by switching the default test user from 'sys' to 'system', which avoids the need for 'as sysdba' privileges that often cause issues in automated environments. Additionally, it significantly optimizes the GitHub Actions CI pipeline by implementing caching for Oracle SQLcl, Ollama models (specifically llama3), and the primary Docker images. The 'ollama' service in docker-compose.yml was updated to use a bind mount to facilitate this caching. Testing robustness was also improved in test.sh by using 'pipefail' and more sophisticated output filtering.

Fixes #15

---
*PR created automatically by Jules for task [3184107083802696869](https://jules.google.com/task/3184107083802696869) started by @chatelao*