### PR TITLE
Save test results as workflow assets

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -119,3 +119,10 @@ jobs:
         if [ -f "test-report.md" ]; then
           cat test-report.md >> $GITHUB_STEP_SUMMARY
         fi
+
+    - name: Upload Test Report as Artifact
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-report
+        path: test-report.md


### PR DESCRIPTION
Modified `.github/workflows/test-integration.yml` to include a new step that uploads the `test-report.md` file as a GitHub Actions artifact named `test-report`. The step uses `if: always()` to ensure the report is uploaded regardless of the test outcome.

Fixes #17

---
*PR created automatically by Jules for task [3054407148236827567](https://jules.google.com/task/3054407148236827567) started by @chatelao*