### PR TITLE
Fix CI Database Connectivity and Test Robustness

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -87,11 +87,14 @@ jobs:
         echo "Waiting for Oracle Database to accept connections..."
         # Additional check to ensure the listener is ready and we can connect
         COUNT=0
-        until echo "SELECT 1 FROM DUAL;" | sql -L -s system/password@127.0.0.1:1521/FREEPDB1 > /dev/null 2>&1; do
+        MAX_CONN_RETRIES=60
+        until CONNECTION_OUTPUT=$(echo "SELECT 1 FROM DUAL;" | sql -L -s system/password@127.0.0.1:1521/FREEPDB1 2>&1); do
             sleep 5
             COUNT=$((COUNT + 1))
-            if [ $COUNT -ge 24 ]; then
-                echo "Error: Oracle Database failed to accept connections after 2 minutes."
+            if [ $COUNT -ge $MAX_CONN_RETRIES ]; then
+                echo "Error: Oracle Database failed to accept connections after 5 minutes."
+                echo "Last connection error:"
+                echo "$CONNECTION_OUTPUT"
                 exit 1
             fi
             echo "Still waiting for connection... ($((COUNT * 5))s)"

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -82,7 +82,21 @@ jobs:
             fi
             echo "Still waiting... ($((COUNT * 10))s)"
         done
-        echo "Oracle Database is healthy."
+        echo "Oracle Database container is healthy."
+
+        echo "Waiting for Oracle Database to accept connections..."
+        # Additional check to ensure the listener is ready and we can connect
+        COUNT=0
+        until echo "SELECT 1 FROM DUAL;" | sql -L -s system/password@127.0.0.1:1521/FREEPDB1 > /dev/null 2>&1; do
+            sleep 5
+            COUNT=$((COUNT + 1))
+            if [ $COUNT -ge 24 ]; then
+                echo "Error: Oracle Database failed to accept connections after 2 minutes."
+                exit 1
+            fi
+            echo "Still waiting for connection... ($((COUNT * 5))s)"
+        done
+        echo "Oracle Database is ready for connections."
 
     - name: Pull LLM Model
       run: |
@@ -99,9 +113,15 @@ jobs:
           echo "llama3 model found in cache. Skipping pull."
         fi
 
+    - name: Install SCOTT Schema
+      env:
+        DB_CONN_STR: "system/password@127.0.0.1:1521/FREEPDB1"
+      run: |
+        bash install/scott.sh
+
     - name: Run Test Script
       env:
-        DB_CONN_STR: "system/password@localhost:1521/FREEPDB1"
+        DB_CONN_STR: "system/password@127.0.0.1:1521/FREEPDB1"
       run: |
         # Ensure we can connect to the DB from the host
         # The docker compose maps 1521:1521

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -85,8 +85,13 @@ jobs:
         echo "Oracle Database container is healthy."
 
         echo "Ensuring SYSTEM account is unlocked and disabling failed login limit..."
-        # This prevents the account from locking during the startup/polling phase
-        docker exec oracle-db .//opt/oracle/runOracle.sh --sql "ALTER USER system ACCOUNT UNLOCK; ALTER PROFILE DEFAULT LIMIT FAILED_LOGIN_ATTEMPTS UNLIMITED;" || true
+        # This prevents the account from locking during the startup/polling phase.
+        # We use sqlplus as the oracle user inside the container.
+        docker exec -u oracle oracle-db bash -c "export ORACLE_SID=FREE; sqlplus -S / as sysdba <<EOF
+ALTER USER system ACCOUNT UNLOCK;
+ALTER PROFILE DEFAULT LIMIT FAILED_LOGIN_ATTEMPTS UNLIMITED;
+EXIT;
+EOF" || true
 
         echo "Waiting for Oracle Database to accept connections..."
         # Additional check to ensure the listener is ready and we can connect
@@ -101,7 +106,10 @@ jobs:
                 echo "Last connection error:"
                 echo "$CONNECTION_OUTPUT"
                 # If still locked, try to unlock again as a last resort
-                docker exec oracle-db .//opt/oracle/runOracle.sh --sql "ALTER USER system ACCOUNT UNLOCK;" || true
+                docker exec -u oracle oracle-db bash -c "export ORACLE_SID=FREE; sqlplus -S / as sysdba <<EOF
+ALTER USER system ACCOUNT UNLOCK;
+EXIT;
+EOF" || true
                 exit 1
             fi
             echo "Still waiting for connection... ($((COUNT * 30))s)"

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -84,20 +84,27 @@ jobs:
         done
         echo "Oracle Database container is healthy."
 
+        echo "Ensuring SYSTEM account is unlocked and disabling failed login limit..."
+        # This prevents the account from locking during the startup/polling phase
+        docker exec oracle-db .//opt/oracle/runOracle.sh --sql "ALTER USER system ACCOUNT UNLOCK; ALTER PROFILE DEFAULT LIMIT FAILED_LOGIN_ATTEMPTS UNLIMITED;" || true
+
         echo "Waiting for Oracle Database to accept connections..."
         # Additional check to ensure the listener is ready and we can connect
         COUNT=0
-        MAX_CONN_RETRIES=60
+        MAX_CONN_RETRIES=20
+        # Increased sleep interval to 30s to reduce login attempts and allow DB to stabilize
         until CONNECTION_OUTPUT=$(echo "SELECT 1 FROM DUAL;" | sql -L -s system/password@127.0.0.1:1521/FREEPDB1 2>&1); do
-            sleep 5
+            sleep 30
             COUNT=$((COUNT + 1))
             if [ $COUNT -ge $MAX_CONN_RETRIES ]; then
-                echo "Error: Oracle Database failed to accept connections after 5 minutes."
+                echo "Error: Oracle Database failed to accept connections after 10 minutes."
                 echo "Last connection error:"
                 echo "$CONNECTION_OUTPUT"
+                # If still locked, try to unlock again as a last resort
+                docker exec oracle-db .//opt/oracle/runOracle.sh --sql "ALTER USER system ACCOUNT UNLOCK;" || true
                 exit 1
             fi
-            echo "Still waiting for connection... ($((COUNT * 5))s)"
+            echo "Still waiting for connection... ($((COUNT * 30))s)"
         done
         echo "Oracle Database is ready for connections."
 

--- a/install/db_config.sh
+++ b/install/db_config.sh
@@ -6,7 +6,7 @@ echo "Configuring Database Connection Environment Variables..."
 # IMPORTANT: Edit these values to match your environment
 export DB_USER="system"
 export DB_PASS="password"
-export DB_HOST="localhost"
+export DB_HOST="127.0.0.1"
 export DB_PORT="1521"
 export DB_SERVICE="FREEPDB1"
 

--- a/install/sqlcl.sh
+++ b/install/sqlcl.sh
@@ -42,8 +42,8 @@ else
 
         # If not already in PATH, add it
         if [[ ":$PATH:" != *":$SQLCL_BIN_DIR:"* ]]; then
-            echo "Adding $SQLCL_BIN_DIR to PATH"
-            export PATH="$PATH:$SQLCL_BIN_DIR"
+            echo "Adding $SQLCL_BIN_DIR to PATH (prepended)"
+            export PATH="$SQLCL_BIN_DIR:$PATH"
         fi
 
         # If in GitHub Actions, add to GITHUB_PATH

--- a/test.sh
+++ b/test.sh
@@ -29,8 +29,14 @@ fi
 # 2. Check SQLcl
 echo "Checking SQLcl..."
 if command -v sql &> /dev/null; then
-    echo "[OK] SQLcl is installed."
-    log_result "Check SQLcl" "✅ OK" "SQLcl is installed"
+    if sql -version 2>&1 | grep -q "SQLcl"; then
+        echo "[OK] SQLcl is installed and verified."
+        log_result "Check SQLcl" "✅ OK" "SQLcl is installed"
+    else
+        echo "[FAIL] 'sql' command found but it is NOT Oracle SQLcl."
+        log_result "Check SQLcl" "❌ FAIL" "'sql' is not Oracle SQLcl"
+        # We might want to exit or skip DB tests
+    fi
 else
     echo "[WARN] SQLcl (sql) not found in PATH."
     log_result "Check SQLcl" "⚠️ WARN" "SQLcl (sql) not found in PATH"
@@ -63,13 +69,19 @@ if command -v sql &> /dev/null; then
     # Try a simple select
     if [ -n "$DB_CONN_STR" ]; then
         # Use pipefail to catch sql errors
-        DB_VERSION=$(set -o pipefail; echo "SELECT version FROM v\$instance;" | sql -s "$DB_CONN_STR" | grep -E "[0-9]+\.[0-9]+")
-        if [ $? -eq 0 ] && [ -n "$DB_VERSION" ]; then
+        DB_OUTPUT=$(set -o pipefail; echo "SELECT version FROM v\$instance;" | sql -L -s "$DB_CONN_STR" 2>&1)
+        DB_EXIT_CODE=$?
+        DB_VERSION=$(echo "$DB_OUTPUT" | grep -E "[0-9]+\.[0-9]+")
+        if [ $DB_EXIT_CODE -eq 0 ] && [ -n "$DB_VERSION" ]; then
             echo "[OK] Database connection successful. Version: $DB_VERSION"
             log_result "DB Connectivity" "✅ OK" "Database version: $DB_VERSION"
         else
             echo "[FAIL] Could not connect to database or retrieve version."
-            log_result "DB Connectivity" "❌ FAIL" "Could not connect to database"
+            echo "Error Details: $DB_OUTPUT"
+            # Extract ORA error if present
+            ORA_ERR=$(echo "$DB_OUTPUT" | grep -o "ORA-[0-9]\+" | head -n 1)
+            [ -z "$ORA_ERR" ] && ORA_ERR="Unknown Error"
+            log_result "DB Connectivity" "❌ FAIL" "Connection failed ($ORA_ERR)"
         fi
     else
         echo "[SKIP] DB_CONN_STR not set. Skipping DB test."
@@ -98,7 +110,7 @@ if command -v sql &> /dev/null && [ -n "$DB_CONN_STR" ]; then
         if [ -n "$CLEAN_SQL" ]; then
             echo "Executing LLM generated SQL: $CLEAN_SQL"
             # Capture output and exit code
-            SQL_OUTPUT=$(echo "$CLEAN_SQL" | sql -s "$DB_CONN_STR" 2>&1)
+            SQL_OUTPUT=$(echo "$CLEAN_SQL" | sql -L -s "$DB_CONN_STR" 2>&1)
             SQL_EXIT_CODE=$?
             CLEAN_RESULT=$(echo "$SQL_OUTPUT" | grep -v "connected" | grep -v "USER          =" | grep -v "URL           =" | grep -v "Error Message =" | xargs)
 
@@ -143,7 +155,7 @@ if command -v sql &> /dev/null && [ -n "$DB_CONN_STR" ]; then
         if [ -n "$CLEAN_SQL" ]; then
             echo "Executing LLM generated SQL on SCOTT schema: $CLEAN_SQL"
             # Capture output and exit code
-            SQL_OUTPUT=$(echo "$CLEAN_SQL" | sql -s "$DB_CONN_STR" 2>&1)
+            SQL_OUTPUT=$(echo "$CLEAN_SQL" | sql -L -s "$DB_CONN_STR" 2>&1)
             SQL_EXIT_CODE=$?
             CLEAN_RESULT=$(echo "$SQL_OUTPUT" | grep -v "connected" | grep -v "USER          =" | grep -v "URL           =" | grep -v "Error Message =" | xargs)
 


### PR DESCRIPTION
This PR addresses the database connection failures observed in the GitHub Actions workflow. The main cause was the test script starting before the Oracle Database listener was fully ready to accept connections. 

Key changes:
1. **Readiness Polling**: The CI workflow now polls the database using `sql -L` until a connection is successful before starting the tests.
2. **Path Priority**: Prepended SQLcl to `PATH` to ensure Oracle's `sql` utility is used instead of system defaults like GNU Parallel.
3. **Robustness**: Switched to `127.0.0.1` for better host resolution and added the `-L` flag to `sql` commands to avoid CI hangs.
4. **Diagnostics**: Improved `test.sh` to capture and display detailed ORA error messages.
5. **Missing Steps**: Added the SCOTT schema installation to the workflow, as it is required for the integration tests.

Fixes #21

---
*PR created automatically by Jules for task [17896458147452446176](https://jules.google.com/task/17896458147452446176) started by @chatelao*