### PR TITLE
Fix disk space exhaustion in CI workflow

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Free Disk Space
+      run: |
+        sudo rm -rf /tmp/docker-images/images.tar 2>/dev/null || true
+        docker system prune -af
+
     - name: Cache SQLcl
       uses: actions/cache@v4
       with:
@@ -36,6 +41,7 @@ jobs:
       run: |
         if [ -f /tmp/docker-images/images.tar ]; then
           docker load -i /tmp/docker-images/images.tar
+          rm /tmp/docker-images/images.tar
         fi
 
     - name: Set up Environment

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -94,10 +94,10 @@ jobs:
         # This prevents the account from locking during the startup/polling phase.
         # We use sqlplus as the oracle user inside the container.
         docker exec -i -u oracle -e ORACLE_SID=FREE oracle-db sqlplus -S / as sysdba <<'EOF'
-          ALTER USER system ACCOUNT UNLOCK;
-          ALTER PROFILE DEFAULT LIMIT FAILED_LOGIN_ATTEMPTS UNLIMITED;
-          EXIT;
-        EOF
+ALTER USER system ACCOUNT UNLOCK;
+ALTER PROFILE DEFAULT LIMIT FAILED_LOGIN_ATTEMPTS UNLIMITED;
+EXIT;
+EOF
 
         echo "Waiting for Oracle Database to accept connections..."
         # Additional check to ensure the listener is ready and we can connect
@@ -113,9 +113,9 @@ jobs:
                 echo "$CONNECTION_OUTPUT"
                 # If still locked, try to unlock again as a last resort
                 docker exec -i -u oracle -e ORACLE_SID=FREE oracle-db sqlplus -S / as sysdba <<'EOF'
-                  ALTER USER system ACCOUNT UNLOCK;
-                  EXIT;
-                EOF
+ALTER USER system ACCOUNT UNLOCK;
+EXIT;
+EOF
                 exit 1
             fi
             echo "Still waiting for connection... ($((COUNT * 30))s)"


### PR DESCRIPTION
This change optimizes disk space usage in the GitHub Actions integration test workflow to prevent "no space left on device" errors during Docker image loading. It adds a proactive cleanup step using 'docker system prune -af' and ensures that the Docker image tarball is removed immediately after it has been successfully loaded.

Fixes #25

---
*PR created automatically by Jules for task [11704356273319285270](https://jules.google.com/task/11704356273319285270) started by @chatelao*