### PR TITLE
Enhance test scripts and error reporting robustness

### DIFF
--- a/complexity-report.md
+++ b/complexity-report.md
@@ -1,3 +1,3 @@
-# Complexity Test Report - Fri May  1 08:31:35 UTC 2026
-## Database Connectivity Error
-The tests could not be executed because the database is unreachable.
+# Complexity Test Report - Fri May  1 13:13:26 UTC 2026
+## Ollama Connectivity Error
+The tests could not be executed because Ollama is unreachable at http://127.0.0.1:11434.

--- a/test.sh
+++ b/test.sh
@@ -16,14 +16,16 @@ log_result() {
     echo "| $test_case | $status | $details |" >> "$REPORT_FILE"
 }
 
+OLLAMA_URL=${OLLAMA_URL:-http://127.0.0.1:11434}
+
 # 1. Check Ollama
 echo "Checking Ollama..."
-if curl -s http://127.0.0.1:11434/api/tags > /dev/null; then
+if curl -s "$OLLAMA_URL/api/tags" > /dev/null; then
     echo "[OK] Ollama is reachable."
-    log_result "Check Ollama" "✅ OK" "Ollama is reachable"
+    log_result "Check Ollama" "✅ OK" "Ollama is reachable at $OLLAMA_URL"
 else
-    echo "[FAIL] Ollama is not reachable on 127.0.0.1:11434."
-    log_result "Check Ollama" "❌ FAIL" "Ollama is not reachable on 127.0.0.1:11434"
+    echo "[FAIL] Ollama is not reachable on $OLLAMA_URL."
+    log_result "Check Ollama" "❌ FAIL" "Ollama is not reachable on $OLLAMA_URL"
 fi
 
 # 2. Check SQLcl
@@ -45,12 +47,13 @@ fi
 # 3. Basic LLM connectivity test
 LLM_MODEL=${LLM_MODEL:-llama3}
 echo "Testing LLM ($LLM_MODEL) responsiveness..."
-    RESPONSE=$(curl -s -X POST http://127.0.0.1:11434/api/generate -d "$(jq -n --arg model "$LLM_MODEL" --arg prompt "Say hello world in SQL" '{model: $model, prompt: $prompt, stream: false}')" | jq -r '.response' 2>/dev/null)
+    RESPONSE=$(curl -s -X POST "$OLLAMA_URL/api/generate" -d "$(jq -n --arg model "$LLM_MODEL" --arg prompt "Say hello world in SQL" '{model: $model, prompt: $prompt, stream: false}')" | jq -r '.response' 2>/dev/null)
 
-if [ -n "$RESPONSE" ]; then
+if [ -n "$RESPONSE" ] && [ "$RESPONSE" != "null" ]; then
     echo "[OK] LLM responded."
-    echo "LLM Response: $RESPONSE"
-    log_result "LLM Connectivity" "✅ OK" "LLM ($LLM_MODEL) responded"
+    # Sanitize response for markdown table
+    SAFE_RESPONSE=$(echo "$RESPONSE" | tr '|' '-' | tr '\n' ' ' | cut -c1-50)
+    log_result "LLM Connectivity" "✅ OK" "LLM ($LLM_MODEL) responded: $SAFE_RESPONSE"
 else
     echo "[FAIL] LLM did not respond or llama3 model is not loaded."
     log_result "LLM Connectivity" "❌ FAIL" "LLM did not respond or model $LLM_MODEL not loaded"
@@ -68,14 +71,14 @@ if command -v sql &> /dev/null; then
         DB_OUTPUT=$(set -o pipefail; echo "SELECT version FROM v\$instance;" | sql -L -s "$DB_CONN_STR" 2>&1)
         DB_EXIT_CODE=$?
         DB_VERSION=$(echo "$DB_OUTPUT" | grep -E "[0-9]+\.[0-9]+")
-        if [ $DB_EXIT_CODE -eq 0 ] && [ -n "$DB_VERSION" ]; then
+        if [ $DB_EXIT_CODE -eq 0 ] && [[ ! "$DB_OUTPUT" =~ "ORA-" ]] && [ -n "$DB_VERSION" ]; then
             echo "[OK] Database connection successful. Version: $DB_VERSION"
             log_result "DB Connectivity" "✅ OK" "Database version: $DB_VERSION"
         else
             echo "[FAIL] Could not connect to database or retrieve version."
             echo "Error Details: $DB_OUTPUT"
-            # Extract ORA error if present
-            ORA_ERR=$(echo "$DB_OUTPUT" | grep -o "ORA-[0-9]\+" | head -n 1)
+            # Extract ORA error if present, sanitize pipes
+            ORA_ERR=$(echo "$DB_OUTPUT" | grep -o "ORA-[0-9]\+.*" | head -n 1 | cut -c1-100 | tr '|' '-')
             [ -z "$ORA_ERR" ] && ORA_ERR="Unknown Error"
             log_result "DB Connectivity" "❌ FAIL" "Connection failed ($ORA_ERR)"
         fi
@@ -93,31 +96,38 @@ if command -v sql &> /dev/null && [ -n "$DB_CONN_STR" ]; then
 
     PROMPT="Generate a simple Oracle SQL SELECT statement to get the current date from dual. Return ONLY the SQL, no explanation."
 
-    INTEGRATION_RESPONSE=$(curl -s -X POST http://127.0.0.1:11434/api/generate -d "$(jq -n --arg model "$LLM_MODEL" --arg prompt "$PROMPT" '{model: $model, prompt: $prompt, stream: false}')" | jq -r '.response' 2>/dev/null)
+    INTEGRATION_RESPONSE=$(curl -s -X POST "$OLLAMA_URL/api/generate" -d "$(jq -n --arg model "$LLM_MODEL" --arg prompt "$PROMPT" '{model: $model, prompt: $prompt, stream: false}')" | jq -r '.response' 2>/dev/null)
 
-    if [ -n "$INTEGRATION_RESPONSE" ]; then
+    if [ -n "$INTEGRATION_RESPONSE" ] && [ "$INTEGRATION_RESPONSE" != "null" ]; then
         # Extraction: use python helper for more robust SQL extraction
         CLEAN_SQL=$(echo "$INTEGRATION_RESPONSE" | python3 install/extract_sql.py)
 
         if [ -n "$CLEAN_SQL" ]; then
             echo "Executing LLM generated SQL: $CLEAN_SQL"
+            # Ensure SQL ends with semicolon
+            [[ "$CLEAN_SQL" != *";" ]] && EXEC_SQL="$CLEAN_SQL;" || EXEC_SQL="$CLEAN_SQL"
             # Capture output and exit code
-            SQL_OUTPUT=$(echo "$CLEAN_SQL" | sql -L -s "$DB_CONN_STR" 2>&1)
+            SQL_OUTPUT=$(echo "$EXEC_SQL" | sql -L -s "$DB_CONN_STR" 2>&1)
             SQL_EXIT_CODE=$?
-            CLEAN_RESULT=$(echo "$SQL_OUTPUT" | grep -v "connected" | grep -v "USER          =" | grep -v "URL           =" | grep -v "Error Message =" | tr -d '\r' | tr '\n' ' ' | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-100)
+            # Sanitize result for markdown table
+            CLEAN_RESULT=$(echo "$SQL_OUTPUT" | grep -v "connected" | grep -v "USER          =" | grep -v "URL           =" | grep -v "Error Message =" | tr -d '\r' | tr '\n' ' ' | tr -s ' ' | sed 's/^ //;s/ $//' | tr '|' '-' | cut -c1-100)
 
             if [ $SQL_EXIT_CODE -eq 0 ] && [[ ! "$SQL_OUTPUT" =~ "ORA-" ]]; then
                 echo "[OK] Integration test successful."
                 echo "Result: $CLEAN_RESULT"
-                log_result "Integration Test" "✅ OK" "SQL executed successfully"
+                log_result "Integration Test" "✅ OK" "SQL executed successfully: \`$CLEAN_SQL\`"
             else
                 echo "[FAIL] Failed to execute generated SQL."
                 echo "Error: $SQL_OUTPUT"
-                log_result "Integration Test" "❌ FAIL" "Failed to execute generated SQL"
+                # Extract ORA error, sanitize pipes
+                ORA_ERR=$(echo "$SQL_OUTPUT" | grep -o "ORA-[0-9]\+.*" | head -n 1 | cut -c1-100 | tr '|' '-')
+                [ -z "$ORA_ERR" ] && ORA_ERR="SQL Execution Error"
+                log_result "Integration Test" "❌ FAIL" "SQL error ($ORA_ERR) for \`$CLEAN_SQL\`"
             fi
         else
             echo "[FAIL] Could not extract SQL from LLM response. Response was: $INTEGRATION_RESPONSE"
-            log_result "Integration Test" "❌ FAIL" "Could not extract SQL from LLM response"
+            SAFE_RESPONSE=$(echo "$INTEGRATION_RESPONSE" | tr '|' '-' | tr '\n' ' ' | cut -c1-50)
+            log_result "Integration Test" "❌ FAIL" "No SQL extracted from: $SAFE_RESPONSE"
         fi
     else
         echo "[FAIL] LLM did not respond for integration test."
@@ -134,31 +144,38 @@ if command -v sql &> /dev/null && [ -n "$DB_CONN_STR" ]; then
 
     PROMPT="Generate an Oracle SQL SELECT statement to find the name (ENAME) and salary (SAL) of all employees in department 10 from the SCOTT.EMP table. Return ONLY the SQL, no explanation."
 
-    SCOTT_RESPONSE=$(curl -s -X POST http://127.0.0.1:11434/api/generate -d "$(jq -n --arg model "$LLM_MODEL" --arg prompt "$PROMPT" '{model: $model, prompt: $prompt, stream: false}')" | jq -r '.response' 2>/dev/null)
+    SCOTT_RESPONSE=$(curl -s -X POST "$OLLAMA_URL/api/generate" -d "$(jq -n --arg model "$LLM_MODEL" --arg prompt "$PROMPT" '{model: $model, prompt: $prompt, stream: false}')" | jq -r '.response' 2>/dev/null)
 
-    if [ -n "$SCOTT_RESPONSE" ]; then
+    if [ -n "$SCOTT_RESPONSE" ] && [ "$SCOTT_RESPONSE" != "null" ]; then
         # Extraction: use python helper for more robust SQL extraction
         CLEAN_SQL=$(echo "$SCOTT_RESPONSE" | python3 install/extract_sql.py)
 
         if [ -n "$CLEAN_SQL" ]; then
             echo "Executing LLM generated SQL on SCOTT schema: $CLEAN_SQL"
+            # Ensure SQL ends with semicolon
+            [[ "$CLEAN_SQL" != *";" ]] && EXEC_SQL="$CLEAN_SQL;" || EXEC_SQL="$CLEAN_SQL"
             # Capture output and exit code
-            SQL_OUTPUT=$(echo "$CLEAN_SQL" | sql -L -s "$DB_CONN_STR" 2>&1)
+            SQL_OUTPUT=$(echo "$EXEC_SQL" | sql -L -s "$DB_CONN_STR" 2>&1)
             SQL_EXIT_CODE=$?
-            CLEAN_RESULT=$(echo "$SQL_OUTPUT" | grep -v "connected" | grep -v "USER          =" | grep -v "URL           =" | grep -v "Error Message =" | tr -d '\r' | tr '\n' ' ' | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-100)
+            # Sanitize result for markdown table
+            CLEAN_RESULT=$(echo "$SQL_OUTPUT" | grep -v "connected" | grep -v "USER          =" | grep -v "URL           =" | grep -v "Error Message =" | tr -d '\r' | tr '\n' ' ' | tr -s ' ' | sed 's/^ //;s/ $//' | tr '|' '-' | cut -c1-100)
 
             if [ $SQL_EXIT_CODE -eq 0 ] && [[ ! "$SQL_OUTPUT" =~ "ORA-" ]]; then
                 echo "[OK] SCOTT integration test successful."
                 echo "Result: $CLEAN_RESULT"
-                log_result "SCOTT Integration" "✅ OK" "SQL executed successfully on SCOTT.EMP"
+                log_result "SCOTT Integration" "✅ OK" "SQL executed successfully on SCOTT.EMP: \`$CLEAN_SQL\`"
             else
                 echo "[FAIL] Failed to execute generated SQL on SCOTT schema."
                 echo "Error: $SQL_OUTPUT"
-                log_result "SCOTT Integration" "❌ FAIL" "Failed to execute generated SQL on SCOTT.EMP"
+                # Extract ORA error, sanitize pipes
+                ORA_ERR=$(echo "$SQL_OUTPUT" | grep -o "ORA-[0-9]\+.*" | head -n 1 | cut -c1-100 | tr '|' '-')
+                [ -z "$ORA_ERR" ] && ORA_ERR="SQL Execution Error"
+                log_result "SCOTT Integration" "❌ FAIL" "SQL error ($ORA_ERR) for \`$CLEAN_SQL\`"
             fi
         else
             echo "[FAIL] Could not extract SQL from LLM response. Response was: $SCOTT_RESPONSE"
-            log_result "SCOTT Integration" "❌ FAIL" "Could not extract SQL from LLM response"
+            SAFE_RESPONSE=$(echo "$SCOTT_RESPONSE" | tr '|' '-' | tr '\n' ' ' | cut -c1-50)
+            log_result "SCOTT Integration" "❌ FAIL" "No SQL extracted from: $SAFE_RESPONSE"
         fi
     else
         echo "[FAIL] LLM did not respond for SCOTT integration test."

--- a/test_complexity.sh
+++ b/test_complexity.sh
@@ -3,6 +3,7 @@
 
 REPORT_FILE="complexity-report.md"
 LLM_MODEL=${LLM_MODEL:-llama3}
+OLLAMA_URL=${OLLAMA_URL:-http://127.0.0.1:11434}
 [ -f "install/db_config.sh" ] && source install/db_config.sh
 
 echo "=== SCOTT/TIGER Complexity Test ==="
@@ -18,14 +19,30 @@ else
     exit 1
 fi
 
-# 2. Check Database Connectivity
+# 2. Check Ollama Connectivity
+echo "Checking Ollama connectivity..."
+if ! curl -s "$OLLAMA_URL/api/tags" > /dev/null; then
+    echo "Error: Could not connect to Ollama at $OLLAMA_URL. Aborting tests."
+    echo "# Complexity Test Report - $(date)" > "$REPORT_FILE"
+    echo "## Ollama Connectivity Error" >> "$REPORT_FILE"
+    echo "The tests could not be executed because Ollama is unreachable at $OLLAMA_URL." >> "$REPORT_FILE"
+    exit 1
+fi
+
+# 3. Check Database Connectivity
 echo "Checking Database connectivity..."
-if ! echo "SELECT 1 FROM DUAL;" | sql -L -s "$DB_CONN_STR" &> /dev/null; then
+DB_CONN_CHECK=$(echo "SELECT 1 FROM DUAL;" | sql -L -s "$DB_CONN_STR" 2>&1)
+DB_EXIT_CODE=$?
+if [ $DB_EXIT_CODE -ne 0 ] || [[ "$DB_CONN_CHECK" =~ "ORA-" ]]; then
     echo "Error: Could not connect to database. Aborting tests."
+    ORA_ERR=$(echo "$DB_CONN_CHECK" | grep -o "ORA-[0-9]\+.*" | head -n 1 | cut -c1-100 | tr '|' '-')
+    [ -z "$ORA_ERR" ] && ORA_ERR="Unknown Connection Error"
     # We write a report with a failure message if DB is down
     echo "# Complexity Test Report - $(date)" > "$REPORT_FILE"
     echo "## Database Connectivity Error" >> "$REPORT_FILE"
     echo "The tests could not be executed because the database is unreachable." >> "$REPORT_FILE"
+    echo "" >> "$REPORT_FILE"
+    echo "Error Details: $ORA_ERR" >> "$REPORT_FILE"
     exit 1
 fi
 
@@ -56,9 +73,9 @@ run_test() {
     Context: Oracle Database, SCOTT schema. Use SCOTT.EMP and SCOTT.DEPT tables.
     Requirement: Return ONLY the Oracle SQL SELECT statement. No explanation. No markdown backticks. No trailing characters."
 
-    RESPONSE=$(curl -s -X POST http://127.0.0.1:11434/api/generate -d "$(jq -n --arg model "$LLM_MODEL" --arg prompt "$PROMPT" '{model: $model, prompt: $prompt, stream: false}')" | jq -r '.response' 2>/dev/null)
+    RESPONSE=$(curl -s -X POST "$OLLAMA_URL/api/generate" -d "$(jq -n --arg model "$LLM_MODEL" --arg prompt "$PROMPT" '{model: $model, prompt: $prompt, stream: false}')" | jq -r '.response' 2>/dev/null)
 
-    if [ -z "$RESPONSE" ]; then
+    if [ -z "$RESPONSE" ] || [ "$RESPONSE" == "null" ]; then
         echo "| $level | $task | ❌ FAIL | No response | |" >> "$REPORT_FILE"
         return
     fi
@@ -67,28 +84,30 @@ run_test() {
     CLEAN_SQL=$(echo "$RESPONSE" | python3 install/extract_sql.py)
 
     if [ -z "$CLEAN_SQL" ]; then
-        echo "| $level | $task | ❌ FAIL | Could not extract SQL | $RESPONSE |" >> "$REPORT_FILE"
+        # Sanitize RESPONSE for markdown table
+        SAFE_RESPONSE=$(echo "$RESPONSE" | tr '|' '-' | tr '\n' ' ' | cut -c1-100)
+        echo "| $level | $task | ❌ FAIL | Could not extract SQL | $SAFE_RESPONSE |" >> "$REPORT_FILE"
         return
     fi
 
-    # Normalize SQL for report (remove newlines and extra spaces)
-    REPORT_SQL=$(echo "$CLEAN_SQL" | tr '\n' ' ' | tr -s ' ')
+    # Normalize SQL for report (remove newlines and extra spaces) and sanitize pipes
+    REPORT_SQL=$(echo "$CLEAN_SQL" | tr '\n' ' ' | tr -s ' ' | tr '|' '-')
 
     echo "Executing: $CLEAN_SQL"
     # Ensure SQL ends with semicolon if not present
-    [[ "$CLEAN_SQL" != *";" ]] && CLEAN_SQL="$CLEAN_SQL;"
+    [[ "$CLEAN_SQL" != *";" ]] && EXEC_SQL="$CLEAN_SQL;" || EXEC_SQL="$CLEAN_SQL"
 
-    SQL_OUTPUT=$(echo "$CLEAN_SQL" | sql -L -s "$DB_CONN_STR" 2>&1)
+    SQL_OUTPUT=$(echo "$EXEC_SQL" | sql -L -s "$DB_CONN_STR" 2>&1)
     SQL_EXIT_CODE=$?
 
-    # Remove connection info and extra whitespace
-    CLEAN_RESULT=$(echo "$SQL_OUTPUT" | grep -v "connected" | grep -v "USER          =" | grep -v "URL           =" | grep -v "Error Message =" | tr -d '\r' | tr '\n' ' ' | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-100)
+    # Remove connection info and extra whitespace, and sanitize pipes
+    CLEAN_RESULT=$(echo "$SQL_OUTPUT" | grep -v "connected" | grep -v "USER          =" | grep -v "URL           =" | grep -v "Error Message =" | tr -d '\r' | tr '\n' ' ' | tr -s ' ' | sed 's/^ //;s/ $//' | tr '|' '-' | cut -c1-100)
 
     if [ $SQL_EXIT_CODE -eq 0 ] && [[ ! "$SQL_OUTPUT" =~ "ORA-" ]]; then
         echo "| $level | $task | ✅ OK | \`$REPORT_SQL\` | $CLEAN_RESULT |" >> "$REPORT_FILE"
     else
-        # Extract ORA error and some context
-        ORA_ERR=$(echo "$SQL_OUTPUT" | grep -o "ORA-[0-9]\+.*" | head -n 1 | cut -c1-100)
+        # Extract ORA error and some context, sanitize pipes
+        ORA_ERR=$(echo "$SQL_OUTPUT" | grep -o "ORA-[0-9]\+.*" | head -n 1 | cut -c1-100 | tr '|' '-')
         [ -z "$ORA_ERR" ] && ORA_ERR="Unknown Error"
         echo "| $level | $task | ❌ FAIL | \`$REPORT_SQL\` | Error: $ORA_ERR |" >> "$REPORT_FILE"
     fi


### PR DESCRIPTION
The errors in `complexity-report.md` were primarily due to the database and Ollama being unreachable in the sandbox environment. I have enhanced the test scripts (`test.sh` and `test_complexity.sh`) to provide much more robust error handling and descriptive reporting when such issues occur. 

Key improvements include:
1. **Detailed Diagnostics**: Scripts now distinguish between Ollama and Database connectivity issues and report specific ORA error messages.
2. **Markdown Safety**: Automated sanitization of pipe characters (`|`) in SQL queries, results, and error messages to ensure that the generated Markdown tables remain correctly formatted.
3. **Execution Reliability**: Added logic to ensure SQL statements sent to Oracle SQLcl always end with a semicolon, improving execution reliability.
4. **Environment Flexibility**: Parameterized the Ollama URL via the `OLLAMA_URL` environment variable for better flexibility in different environments.
5. **Cleanliness**: Removed large, irrelevant log files that were inadvertently created during environment investigation.

These changes ensure that even when services are down, the project provides clear, actionable feedback in its reports.

Fixes #37

---
*PR created automatically by Jules for task [875799186701205907](https://jules.google.com/task/875799186701205907) started by @chatelao*