### PR TITLE
Upgrade CI/CD process to support multiple LLMs

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -12,6 +12,10 @@ permissions:
 jobs:
   install-and-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        model: [llama3, "gemma:2b"]
 
     steps:
     - uses: actions/checkout@v4
@@ -36,7 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ./ollama_data
-        key: ${{ runner.os }}-ollama-llama3
+        key: ${{ runner.os }}-ollama-${{ matrix.model }}
 
     - name: Cache Docker Images
       id: cache-docker-images
@@ -155,11 +159,11 @@ jobs:
         echo "Ollama service is ready."
 
         # Check if the model already exists to avoid redundant pull
-        if ! docker exec ollama ollama list | grep -q "llama3"; then
-          echo "llama3 model not found in cache. Pulling..."
-          docker exec ollama ollama pull llama3
+        if ! docker exec ollama ollama list | grep -q "${{ matrix.model }}"; then
+          echo "${{ matrix.model }} model not found in cache. Pulling..."
+          docker exec ollama ollama pull ${{ matrix.model }}
         else
-          echo "llama3 model found in cache. Skipping pull."
+          echo "${{ matrix.model }} model found in cache. Skipping pull."
         fi
 
     - name: Install SCOTT Schema
@@ -171,6 +175,7 @@ jobs:
     - name: Run Test Script
       env:
         DB_CONN_STR: "system/password@127.0.0.1:1521/FREEPDB1"
+        LLM_MODEL: "${{ matrix.model }}"
       run: |
         # Ensure we can connect to the DB from the host
         # The docker compose maps 1521:1521
@@ -179,24 +184,23 @@ jobs:
     - name: Run Complexity Test Script
       env:
         DB_CONN_STR: "system/password@127.0.0.1:1521/FREEPDB1"
+        LLM_MODEL: "${{ matrix.model }}"
       run: |
         bash test_complexity.sh
 
-    - name: Setup Pages
-      if: always() && github.ref == 'refs/heads/main'
-      uses: actions/configure-pages@v5
-
-    - name: Prepare GitHub Pages
-      if: always() && github.ref == 'refs/heads/main'
+    - name: Set Safe Model Name
+      if: always()
+      id: safe_name
       run: |
-        mkdir -p _site
-        python3 install/generate_report.py > _site/index.html
+        SAFE_NAME=$(echo "${{ matrix.model }}" | sed 's/:/-/g')
+        echo "name=${SAFE_NAME}" >> $GITHUB_OUTPUT
 
-    - name: Upload Pages Artifact
-      if: always() && github.ref == 'refs/heads/main'
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: _site
+    - name: Rename Reports
+      if: always()
+      run: |
+        SAFE_MODEL_NAME="${{ steps.safe_name.outputs.name }}"
+        [ -f test-report.md ] && mv test-report.md test-report-${SAFE_MODEL_NAME}.md
+        [ -f complexity-report.md ] && mv complexity-report.md complexity-report-${SAFE_MODEL_NAME}.md
 
     - name: Save Docker Images
       if: steps.cache-docker-images.outputs.cache-hit != 'true'
@@ -207,22 +211,52 @@ jobs:
     - name: Upload Test Report to Summary
       if: always()
       run: |
-        if [ -f "test-report.md" ]; then
-          cat test-report.md >> $GITHUB_STEP_SUMMARY
+        SAFE_MODEL_NAME="${{ steps.safe_name.outputs.name }}"
+        if [ -f "test-report-${SAFE_MODEL_NAME}.md" ]; then
+          cat test-report-${SAFE_MODEL_NAME}.md >> $GITHUB_STEP_SUMMARY
         fi
 
     - name: Upload Test Report as Artifact
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: test-reports
+        name: test-reports-${{ steps.safe_name.outputs.name }}
         path: |
-          test-report.md
-          complexity-report.md
+          test-report-*.md
+          complexity-report-*.md
+
+  aggregate-reports:
+    needs: install-and-test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-reports-*
+          merge-multiple: true
+
+      - name: Setup Pages
+        if: github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v5
+
+      - name: Prepare GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p _site
+          python3 install/generate_report.py > _site/index.html
+
+      - name: Upload Pages Artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
 
   deploy:
-    needs: install-and-test
-    if: always() && github.ref == 'refs/heads/main' && (needs.install-and-test.result == 'success' || needs.install-and-test.result == 'failure')
+    needs: aggregate-reports
+    if: always() && github.ref == 'refs/heads/main' && (needs.aggregate-reports.result == 'success')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [x] Fehlerbehebung bei der Datenbankverbindung (Umstellung auf `system` User).
 - [x] Optimierung des CI/CD Workflows (Disk Cleanup, Readiness Checks, robuste Pfade).
 - [x] Verbesserung der Test-Robustheit und des Berichtswesens (SQL-Normalisierung, detaillierte ORA-Fehler).
+- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3 und gemma:2b).
 
 ## Fortschrittsbewertung
 Der Fortschritt wird durch das Bestehen des `test.sh` Skripts in der CI/CD-Pipeline gemessen. Die Pipeline wurde optimiert, um die notwendige Infrastruktur (Datenbank und LLM) während des Laufs bereitzustellen.

--- a/install/generate_report.py
+++ b/install/generate_report.py
@@ -1,6 +1,7 @@
 import sys
 import html
 import os
+import glob
 
 def md_to_html(md_text):
     lines = md_text.splitlines()
@@ -51,11 +52,19 @@ def md_to_html(md_text):
 
 if __name__ == "__main__":
     report_html = ""
-    for filename in ["test-report.md", "complexity-report.md"]:
-        if os.path.exists(filename):
-            with open(filename, "r") as f:
-                report_html += md_to_html(f.read())
-                report_html += "<hr>"
+    # Find all model-specific reports first
+    report_files = glob.glob("*-report-*.md")
+    # If none found, fall back to default names (for local testing)
+    if not report_files:
+        report_files = [f for f in ["test-report.md", "complexity-report.md"] if os.path.exists(f)]
+
+    # Sort files to ensure consistent order
+    report_files.sort()
+
+    for filename in report_files:
+        with open(filename, "r") as f:
+            report_html += md_to_html(f.read())
+            report_html += "<hr>"
 
     print(f"""
 <html><head><title>Test Results</title><style>

--- a/test.sh
+++ b/test.sh
@@ -2,9 +2,10 @@
 # test.sh - Main test script for LLM and Oracle DB integration
 
 REPORT_FILE="test-report.md"
+LLM_MODEL=${LLM_MODEL:-llama3}
 
 echo "=== LLM x Oracle SQLcl Integration Test ==="
-echo "# Test Report - $(date)" > "$REPORT_FILE"
+echo "# Test Report ($LLM_MODEL) - $(date)" > "$REPORT_FILE"
 echo "" >> "$REPORT_FILE"
 echo "| Test Case | Status | Details |" >> "$REPORT_FILE"
 echo "|-----------|--------|---------|" >> "$REPORT_FILE"
@@ -43,7 +44,6 @@ else
 fi
 
 # 3. Basic LLM connectivity test
-LLM_MODEL=${LLM_MODEL:-llama3}
 echo "Testing LLM ($LLM_MODEL) responsiveness..."
     RESPONSE=$(curl -s -X POST http://127.0.0.1:11434/api/generate -d "$(jq -n --arg model "$LLM_MODEL" --arg prompt "Say hello world in SQL" '{model: $model, prompt: $prompt, stream: false}')" | jq -r '.response' 2>/dev/null)
 

--- a/test_complexity.sh
+++ b/test_complexity.sh
@@ -23,13 +23,13 @@ echo "Checking Database connectivity..."
 if ! echo "SELECT 1 FROM DUAL;" | sql -L -s "$DB_CONN_STR" &> /dev/null; then
     echo "Error: Could not connect to database. Aborting tests."
     # We write a report with a failure message if DB is down
-    echo "# Complexity Test Report - $(date)" > "$REPORT_FILE"
+    echo "# Complexity Test Report ($LLM_MODEL) - $(date)" > "$REPORT_FILE"
     echo "## Database Connectivity Error" >> "$REPORT_FILE"
     echo "The tests could not be executed because the database is unreachable." >> "$REPORT_FILE"
     exit 1
 fi
 
-echo "# Complexity Test Report - $(date)" > "$REPORT_FILE"
+echo "# Complexity Test Report ($LLM_MODEL) - $(date)" > "$REPORT_FILE"
 echo "" >> "$REPORT_FILE"
 echo "| Level | Task | Status | SQL | Result |" >> "$REPORT_FILE"
 echo "|-------|------|--------|-----|--------|" >> "$REPORT_FILE"


### PR DESCRIPTION
This change upgrades the project's CI/CD pipeline to test integration with multiple Large Language Models (LLMs) concurrently. 

Key improvements:
1. **Matrix Strategy**: The `install-and-test` job now uses a matrix to run tests against both `llama3` and `gemma:2b` (identified as the smallest available Gemma model).
2. **Enhanced Reporting**: 
    - Test scripts now dynamically include the active model name in their Markdown report headers.
    - The report generation script (`install/generate_report.py`) has been upgraded to automatically discover and aggregate all model-specific reports into a single HTML summary.
3. **Robust CI/CD Workflow**:
    - Each matrix run uses its own Ollama model cache.
    - Model-specific reports are renamed and uploaded as distinct artifacts.
    - A new `aggregate-reports` job collects all matrix results and prepares the final GitHub Pages site.
    - Artifact naming and file paths are sanitized to handle model names with special characters (e.g., converting `gemma:2b` to `gemma-2b` for filenames).
4. **Roadmap Updated**: Marked the multi-LLM support milestone as complete.

Fixes #41

---
*PR created automatically by Jules for task [10344242745402333629](https://jules.google.com/task/10344242745402333629) started by @chatelao*