### PR TITLE
Add Gemma 4 26B model to CI/CD tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [llama3, "gemma:2b", "gemma2:9b"]
+        model: [llama3, "gemma:2b", "gemma2:9b", "gemma4:26b"]
 
     steps:
     - uses: actions/checkout@v4

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [x] Fehlerbehebung bei der Datenbankverbindung (Umstellung auf `system` User).
 - [x] Optimierung des CI/CD Workflows (Disk Cleanup, Readiness Checks, robuste Pfade).
 - [x] Verbesserung der Test-Robustheit und des Berichtswesens (SQL-Normalisierung, detaillierte ORA-Fehler).
-- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b und gemma2:9b).
+- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:9b und gemma4:26b).
 
 ## Fortschrittsbewertung
 Der Fortschritt wird durch das Bestehen des `test.sh` Skripts in der CI/CD-Pipeline gemessen. Die Pipeline wurde optimiert, um die notwendige Infrastruktur (Datenbank und LLM) während des Laufs bereitzustellen.


### PR DESCRIPTION
This change adds the `gemma4:26b` model to the CI/CD test matrix, increasing the total number of tested models to four. It also updates the project roadmap to reflect this improvement. The addition of this larger model (approx. 18GB) utilizes existing disk space optimization and caching strategies in the CI pipeline.

Fixes #45

---
*PR created automatically by Jules for task [17937347573848190461](https://jules.google.com/task/17937347573848190461) started by @chatelao*