### PR TITLE
Add Mistral and Phi-3 to CI/CD

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [llama3, "gemma:2b", "gemma2:9b", "gemma4:26b", "gemma4:31b"]
+        model: [llama3, "gemma:2b", "gemma2:9b", "gemma4:26b", "gemma4:31b", mistral, phi3]
 
     steps:
     - uses: actions/checkout@v4

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [x] Fehlerbehebung bei der Datenbankverbindung (Umstellung auf `system` User).
 - [x] Optimierung des CI/CD Workflows (Disk Cleanup, Readiness Checks, robuste Pfade).
 - [x] Verbesserung der Test-Robustheit und des Berichtswesens (SQL-Normalisierung, detaillierte ORA-Fehler).
-- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:9b und gemma4:31b).
+- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:9b, gemma4:31b, mistral und phi3).
 
 ## Fortschrittsbewertung
 Der Fortschritt wird durch das Bestehen des `test.sh` Skripts in der CI/CD-Pipeline gemessen. Die Pipeline wurde optimiert, um die notwendige Infrastruktur (Datenbank und LLM) während des Laufs bereitzustellen.


### PR DESCRIPTION
This PR adds two popular open LLMs, Mistral and Phi-3, to the CI/CD integration test suite. This expands the model coverage for automated testing against Oracle Database.

Fixes #49

---
*PR created automatically by Jules for task [17020621565225728492](https://jules.google.com/task/17020621565225728492) started by @chatelao*