### PR TITLE
Add Phi-3 to model options and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ docker compose up -d
 ```
 
 ### 2. LLM Modell vorbereiten
-Stelle sicher, dass Ollama läuft und lade das gewünschte Modell:
+Stelle sicher, dass Ollama läuft und lade das gewünschte Modell (z.B. `llama3` oder `phi3`):
 ```bash
 docker exec -it ollama ollama pull llama3
+# oder
+docker exec -it ollama ollama pull phi3
 ```
 
 ### 3. Datenbank konfigurieren

--- a/install/llm.sh
+++ b/install/llm.sh
@@ -32,7 +32,7 @@ else
     echo "Ollama service is ready."
 fi
 
-# Pull a small model for testing
+# Pull a model for testing (e.g., llama3, phi3, mistral, gemma:2b)
 LLM_MODEL=${LLM_MODEL:-llama3}
 echo "Pulling $LLM_MODEL model (this might take a while)..."
 ollama pull "$LLM_MODEL"

--- a/test.sh
+++ b/test.sh
@@ -52,7 +52,7 @@ if [ -n "$RESPONSE" ]; then
     echo "LLM Response: $RESPONSE"
     log_result "LLM Connectivity" "✅ OK" "LLM ($LLM_MODEL) responded"
 else
-    echo "[FAIL] LLM did not respond or llama3 model is not loaded."
+    echo "[FAIL] LLM did not respond or $LLM_MODEL model is not loaded."
     log_result "LLM Connectivity" "❌ FAIL" "LLM did not respond or model $LLM_MODEL not loaded"
 fi
 

--- a/test_complexity.sh
+++ b/test_complexity.sh
@@ -2,6 +2,7 @@
 # test_complexity.sh - 10 Queries of increasing complexity for SCOTT/TIGER
 
 REPORT_FILE="complexity-report.md"
+# Default model is llama3, but others like phi3 or mistral can be used via env var
 LLM_MODEL=${LLM_MODEL:-llama3}
 [ -f "install/db_config.sh" ] && source install/db_config.sh
 


### PR DESCRIPTION
I have added Phi-3 as a more visible model option in the project. While it was already present in the CI matrix, I have updated the documentation (README.md) and scripts (test.sh, test_complexity.sh, install/llm.sh) to include it in examples, comments, and dynamic log messages. This ensures a consistent experience when using Phi-3 instead of the default llama3.

Fixes #51

---
*PR created automatically by Jules for task [13214070976674608405](https://jules.google.com/task/13214070976674608405) started by @chatelao*