### PR TITLE
Add Qwen2.5 to model options

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [llama3, "gemma:2b", "gemma2:9b", "gemma4:26b", "gemma4:31b", mistral, phi3]
+        model: [llama3, "gemma:2b", "gemma2:9b", "gemma4:26b", "gemma4:31b", mistral, phi3, qwen2.5]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ docker compose up -d
 ```
 
 ### 2. LLM Modell vorbereiten
-Stelle sicher, dass Ollama läuft und lade das gewünschte Modell (z.B. `llama3` oder `phi3`):
+Stelle sicher, dass Ollama läuft und lade das gewünschte Modell (z.B. `llama3`, `phi3` oder `qwen2.5`):
 ```bash
 docker exec -it ollama ollama pull llama3
 # oder
-docker exec -it ollama ollama pull phi3
+docker exec -it ollama ollama pull qwen2.5
 ```
 
 ### 3. Datenbank konfigurieren

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [x] Fehlerbehebung bei der Datenbankverbindung (Umstellung auf `system` User).
 - [x] Optimierung des CI/CD Workflows (Disk Cleanup, Readiness Checks, robuste Pfade).
 - [x] Verbesserung der Test-Robustheit und des Berichtswesens (SQL-Normalisierung, detaillierte ORA-Fehler).
-- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:9b, gemma4:31b, mistral und phi3).
+- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:9b, gemma4:31b, mistral, phi3 und qwen2.5).
 
 ## Fortschrittsbewertung
 Der Fortschritt wird durch das Bestehen des `test.sh` Skripts in der CI/CD-Pipeline gemessen. Die Pipeline wurde optimiert, um die notwendige Infrastruktur (Datenbank und LLM) während des Laufs bereitzustellen.

--- a/install/llm.sh
+++ b/install/llm.sh
@@ -32,7 +32,7 @@ else
     echo "Ollama service is ready."
 fi
 
-# Pull a model for testing (e.g., llama3, phi3, mistral, gemma:2b)
+# Pull a model for testing (e.g., llama3, phi3, mistral, gemma:2b, qwen2.5)
 LLM_MODEL=${LLM_MODEL:-llama3}
 echo "Pulling $LLM_MODEL model (this might take a while)..."
 ollama pull "$LLM_MODEL"


### PR DESCRIPTION
Added the latest Qwen model (`qwen2.5`) to the integration test suite. This includes updating the CI/CD workflow matrix, documentation (README.md and ROADMAP.md), and installation script comments. Verified script integrity and ensured the changes follow existing project patterns.

Fixes #53

---
*PR created automatically by Jules for task [5832344212148698866](https://jules.google.com/task/5832344212148698866) started by @chatelao*