### PR TITLE
Upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -18,7 +18,7 @@ jobs:
         model: [llama3, "gemma:2b", "gemma2:9b", "gemma4:26b", "gemma4:31b", mistral, phi3, qwen2.5]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Free Disk Space
       run: |
@@ -31,20 +31,20 @@ jobs:
         docker system prune -af
 
     - name: Cache SQLcl
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/sqlcl
         key: ${{ runner.os }}-sqlcl-latest
 
     - name: Cache Ollama Models
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ./ollama_data
         key: ${{ runner.os }}-ollama-${{ matrix.model }}
 
     - name: Cache Docker Images
       id: cache-docker-images
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: /tmp/docker-images
         key: ${{ runner.os }}-docker-images-${{ hashFiles('docker-compose.yml') }}
@@ -62,7 +62,7 @@ jobs:
         sudo apt-get install -y jq curl unzip zstd
 
     - name: Set up Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '17'
@@ -218,7 +218,7 @@ jobs:
 
     - name: Upload Test Report as Artifact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-reports-${{ steps.safe_name.outputs.name }}
         path: |
@@ -230,17 +230,17 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: test-reports-*
           merge-multiple: true
 
       - name: Setup Pages
         if: github.ref == 'refs/heads/main'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Prepare GitHub Pages
         if: github.ref == 'refs/heads/main'
@@ -250,7 +250,7 @@ jobs:
 
       - name: Upload Pages Artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -264,4 +264,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
This PR upgrades the GitHub Actions used in the integration test workflow to versions that support the Node.js 24 runtime. This proactive update avoids potential failures when GitHub Actions forces the use of Node.js 24 in the future and resolves deprecation warnings related to Node.js 20. All actions have been updated to their latest major stable versions as confirmed by the GitHub API and release notes.

Fixes #55

---
*PR created automatically by Jules for task [5683244292247497261](https://jules.google.com/task/5683244292247497261) started by @chatelao*