### PR TITLE
Add Model Comparison Matrix to CI/CD Reports

### DIFF
--- a/install/generate_report.py
+++ b/install/generate_report.py
@@ -2,6 +2,84 @@ import sys
 import html
 import os
 import glob
+import re
+
+def parse_report_for_matrix(filename):
+    # Extract model name from filename like complexity-report-llama3.md or test-report-llama3.md
+    model_match = re.search(r'report-(.+)\.md', filename)
+    if not model_match:
+        return None, {}
+    model_name = model_match.group(1)
+
+    tasks = {}
+    with open(filename, 'r') as f:
+        for line in f:
+            if '|' in line and '---' not in line:
+                parts = [p.strip() for p in line.split('|')]
+                # Filter out header rows
+                if not parts or len(parts) < 3: continue
+                if parts[1].lower() in ['level', 'test case', 'task']: continue
+
+                if 'complexity-report' in filename:
+                    # | Level | Task | Status | SQL | Result |
+                    if len(parts) >= 4:
+                        task = parts[2]
+                        status = parts[3]
+                        tasks[task] = status
+                else:
+                    # | Test Case | Status | Details |
+                    if len(parts) >= 3:
+                        task = parts[1]
+                        status = parts[2]
+                        tasks[task] = status
+    return model_name, tasks
+
+def generate_matrix_html():
+    complexity_files = glob.glob("complexity-report-*.md")
+    test_files = glob.glob("test-report-*.md")
+
+    all_models = set()
+    all_tasks = []
+    matrix = {} # (task, model) -> status
+
+    # Process files to build the matrix
+    for f in sorted(complexity_files) + sorted(test_files):
+        model, tasks = parse_report_for_matrix(f)
+        if not model: continue
+        all_models.add(model)
+        for task, status in tasks.items():
+            if task not in all_tasks:
+                all_tasks.append(task)
+            matrix[(task, model)] = status
+
+    if not all_tasks:
+        return ""
+
+    models = sorted(list(all_models))
+
+    html_out = "<h2>Model Comparison Matrix</h2>"
+    html_out += "<table><thead><tr><th>Task</th>"
+    for m in models:
+        html_out += f"<th>{m}</th>"
+    html_out += "</tr></thead><tbody>"
+
+    for t in all_tasks:
+        html_out += f"<tr><td>{html.escape(t)}</td>"
+        for m in models:
+            status = matrix.get((t, m), "-")
+            icon = status
+            if "OK" in status or "✅" in status:
+                icon = "✅"
+            elif "FAIL" in status or "❌" in status:
+                icon = "❌"
+            elif "SKIP" in status or "⏭️" in status:
+                icon = "⏭️"
+
+            html_out += f"<td style='text-align:center'>{icon}</td>"
+        html_out += "</tr>"
+
+    html_out += "</tbody></table>"
+    return html_out
 
 def md_to_html(md_text):
     lines = md_text.splitlines()
@@ -51,6 +129,8 @@ def md_to_html(md_text):
     return "\n".join(html_output)
 
 if __name__ == "__main__":
+    matrix_html = generate_matrix_html()
+
     report_html = ""
     # Find all model-specific reports first
     report_files = glob.glob("*-report-*.md")
@@ -67,16 +147,25 @@ if __name__ == "__main__":
             report_html += "<hr>"
 
     print(f"""
-<html><head><title>Test Results</title><style>
+<!DOCTYPE html>
+<html><head><title>LLM Oracle SQLcl Test Results</title>
+<meta charset="UTF-8">
+<style>
 body{{font-family:sans-serif;margin:2em;line-height:1.6;color:#333;max-width:1200px;margin:auto;}}
 table{{border-collapse:collapse;width:100%;margin-bottom:2em;}}
 th,td{{border:1px solid #ddd;padding:12px;text-align:left;}}
-th{{background-color:#f8f9fa;}}
+th{{background-color:#f8f9fa;position: sticky; top: 0;}}
 tr:nth-child(even){{background-color:#f2f2f2;}}
-h1,h2{{color:#0056b3;}}
-hr{{margin:2em 0;}}
+tr:hover {{background-color: #e9ecef;}}
+h1,h2{{color:#0056b3;border-bottom: 2px solid #0056b3; padding-bottom: 0.3em;}}
+hr{{margin:3em 0; border: 0; border-top: 5px solid #eee;}}
+.matrix-container {{ overflow-x: auto; }}
 </style></head><body>
 <h1>LLM x Oracle SQLcl Integration Test Results</h1>
+<div class="matrix-container">
+{matrix_html}
+</div>
+<hr>
 {report_html}
 </body></html>
 """)


### PR DESCRIPTION
This change enhances the automated test reporting by adding a "Model Comparison Matrix" to the generated HTML report. 

Key changes:
- Updated `install/generate_report.py` to parse all model-specific markdown reports.
- Added logic to extract tasks and statuses from both connectivity and complexity tests.
- Generated a consolidated HTML table (matrix) showing model performance across all tasks using visual indicators (✅, ❌, ⏭️).
- Improved the report's CSS for better readability and navigation.

The updated report is automatically deployed to GitHub Pages via the existing GitHub Actions workflow on every push to the main branch.

Fixes #57

---
*PR created automatically by Jules for task [6246962724794678179](https://jules.google.com/task/6246962724794678179) started by @chatelao*