### PR TITLE
Fix CI crashes for large Gemma models by using resource-efficient variants

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [llama3, "gemma:2b", "gemma2:9b", "gemma4:26b", "gemma4:31b", mistral, phi3, qwen2.5]
+        model: [llama3, "gemma:2b", "gemma2:2b", "gemma4:e2b", "gemma4:31b-cloud", mistral, phi3, qwen2.5]
 
     steps:
     - uses: actions/checkout@v6

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [x] Fehlerbehebung bei der Datenbankverbindung (Umstellung auf `system` User).
 - [x] Optimierung des CI/CD Workflows (Disk Cleanup, Readiness Checks, robuste Pfade).
 - [x] Verbesserung der Test-Robustheit und des Berichtswesens (SQL-Normalisierung, detaillierte ORA-Fehler).
-- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:9b, gemma4:31b, mistral, phi3 und qwen2.5).
+- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:2b, gemma4:e2b, gemma4:31b-cloud, mistral, phi3 und qwen2.5).
 
 ## Fortschrittsbewertung
 Der Fortschritt wird durch das Bestehen des `test.sh` Skripts in der CI/CD-Pipeline gemessen. Die Pipeline wurde optimiert, um die notwendige Infrastruktur (Datenbank und LLM) während des Laufs bereitzustellen.


### PR DESCRIPTION
The CI/CD pipeline was experiencing crashes during integration tests for large Gemma models (gemma4:26b and gemma4:31b) due to the limited RAM (7GB) and disk space available on standard GitHub Actions runners. 

This fix replaces these models with more appropriate versions:
1. `gemma2:9b` is downgraded to `gemma2:2b` for better stability.
2. `gemma4:26b` is replaced with the Edge variant `gemma4:e2b`.
3. `gemma4:31b` is replaced with `gemma4:31b-cloud`, which executes on Ollama's infrastructure, thus avoiding local resource constraints.

The ROADMAP.md has been updated to match these changes.

Fixes #63

---
*PR created automatically by Jules for task [181513743031537545](https://jules.google.com/task/181513743031537545) started by @chatelao*