### PR TITLE
Add Qwen-3.6-35B-A3B model to integration tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [llama3, "gemma:2b", "gemma2:9b", "gemma4:26b", "gemma4:31b", mistral, phi3, qwen2.5]
+        model: [llama3, "gemma:2b", "gemma2:9b", "gemma4:26b", "gemma4:31b", mistral, phi3, qwen2.5, "qwen3.6:35b-a3b"]
 
     steps:
     - uses: actions/checkout@v6

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [x] Fehlerbehebung bei der Datenbankverbindung (Umstellung auf `system` User).
 - [x] Optimierung des CI/CD Workflows (Disk Cleanup, Readiness Checks, robuste Pfade).
 - [x] Verbesserung der Test-Robustheit und des Berichtswesens (SQL-Normalisierung, detaillierte ORA-Fehler).
-- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:9b, gemma4:31b, mistral, phi3 und qwen2.5).
+- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:9b, gemma4:31b, mistral, phi3, qwen2.5 und qwen3.6:35b-a3b).
 
 ## Fortschrittsbewertung
 Der Fortschritt wird durch das Bestehen des `test.sh` Skripts in der CI/CD-Pipeline gemessen. Die Pipeline wurde optimiert, um die notwendige Infrastruktur (Datenbank und LLM) während des Laufs bereitzustellen.


### PR DESCRIPTION
This change adds the Qwen-3.6-35B-A3B model (using the Ollama tag 'qwen3.6:35b-a3b') to the project's integration test suite. It updates the CI/CD workflow to include this model in the automated test matrix and records the addition in the project roadmap. Verification has been performed to ensure that the reporting scripts correctly handle the new model name.

Fixes #62

---
*PR created automatically by Jules for task [5142226805182614309](https://jules.google.com/task/5142226805182614309) started by @chatelao*