### PR TITLE
Add generation timestamp to report page

### DIFF
--- a/install/generate_report.py
+++ b/install/generate_report.py
@@ -3,6 +3,7 @@ import html
 import os
 import glob
 import re
+from datetime import datetime, timezone
 
 def parse_report_for_matrix(filename):
     # Extract model name from filename like complexity-report-llama3.md or test-report-llama3.md
@@ -130,6 +131,7 @@ def md_to_html(md_text):
 
 if __name__ == "__main__":
     matrix_html = generate_matrix_html()
+    timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
 
     report_html = ""
     # Find all model-specific reports first
@@ -162,6 +164,7 @@ hr{{margin:3em 0; border: 0; border-top: 5px solid #eee;}}
 .matrix-container {{ overflow-x: auto; }}
 </style></head><body>
 <h1>LLM x Oracle SQLcl Integration Test Results</h1>
+<p style="font-style: italic;">Last updated: {timestamp}</p>
 <div class="matrix-container">
 {matrix_html}
 </div>


### PR DESCRIPTION
This change adds a generation timestamp to the top of the LLM Oracle SQLcl Test Results report. The timestamp is formatted in UTC and appears just below the main heading to provide context on when the report was last generated.

Key changes:
- Modified `install/generate_report.py` to calculate and embed a `timestamp` variable.
- Updated the HTML template to include a `<p>` tag with the timestamp.
- Verified the visual change with a Playwright script and screenshot.

Fixes #67

---
*PR created automatically by Jules for task [13694892257517044788](https://jules.google.com/task/13694892257517044788) started by @chatelao*