### PR TITLE
Remove failing Qwen model from CI

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [llama3, "gemma:2b", "gemma2:2b", "gemma4:e2b", "gemma4:31b-cloud", mistral, phi3, qwen2.5, "qwen3.6:35b-a3b"]
+        model: [llama3, "gemma:2b", "gemma2:2b", "gemma4:e2b", "gemma4:31b-cloud", mistral, phi3, qwen2.5]
 
     steps:
     - uses: actions/checkout@v6

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,6 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [x] Fehlerbehebung bei der Datenbankverbindung (Umstellung auf `system` User).
 - [x] Optimierung des CI/CD Workflows (Disk Cleanup, Readiness Checks, robuste Pfade).
 - [x] Verbesserung der Test-Robustheit und des Berichtswesens (SQL-Normalisierung, detaillierte ORA-Fehler).
-- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:9b, gemma4:31b, mistral, phi3 und qwen2.5).
 - [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:2b, gemma4:e2b, gemma4:31b-cloud, mistral, phi3 und qwen2.5).
 
 ## Fortschrittsbewertung

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [x] Fehlerbehebung bei der Datenbankverbindung (Umstellung auf `system` User).
 - [x] Optimierung des CI/CD Workflows (Disk Cleanup, Readiness Checks, robuste Pfade).
 - [x] Verbesserung der Test-Robustheit und des Berichtswesens (SQL-Normalisierung, detaillierte ORA-Fehler).
-- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:9b, gemma4:31b, mistral, phi3, qwen2.5 und qwen3.6:35b-a3b).
+- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:9b, gemma4:31b, mistral, phi3 und qwen2.5).
 - [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:2b, gemma4:e2b, gemma4:31b-cloud, mistral, phi3 und qwen2.5).
 
 ## Fortschrittsbewertung


### PR DESCRIPTION
The qwen3.6:35b-a3b model (35B parameters) was causing CI failures due to resource exhaustion (RAM/disk) on standard GitHub Action runners. This change removes the model from the CI matrix and aligns the ROADMAP.md to reflect this decision, ensuring pipeline stability.

Fixes #68

---
*PR created automatically by Jules for task [9279339205439671572](https://jules.google.com/task/9279339205439671572) started by @chatelao*