### PR TITLE
Update Gemma 4 models in CI and roadmap

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [llama3, "gemma:2b", "gemma2:2b", "gemma4:e2b", "gemma4:31b-cloud", mistral, phi3, qwen2.5]
+        model: [llama3, "gemma:2b", "gemma2:2b", "gemma4:e2b", "gemma4:e4b", mistral, phi3, qwen2.5]
 
     steps:
     - uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 test-report.md
 complexity-report.md
 ollama.log
+__pycache__/
+*.pyc

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ Dieses Projekt zielt darauf ab, das Zusammenspiel zwischen einem lokalen Large L
 - [x] Fehlerbehebung bei der Datenbankverbindung (Umstellung auf `system` User).
 - [x] Optimierung des CI/CD Workflows (Disk Cleanup, Readiness Checks, robuste Pfade).
 - [x] Verbesserung der Test-Robustheit und des Berichtswesens (SQL-Normalisierung, detaillierte ORA-Fehler).
-- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:2b, gemma4:e2b, gemma4:31b-cloud, mistral, phi3 und qwen2.5).
+- [x] Upgrade auf Multi-LLM-Unterstützung in der CI/CD-Pipeline (llama3, gemma:2b, gemma2:2b, gemma4:e2b, gemma4:e4b, mistral, phi3 und qwen2.5).
 
 ## Fortschrittsbewertung
 Der Fortschritt wird durch das Bestehen des `test.sh` Skripts in der CI/CD-Pipeline gemessen. Die Pipeline wurde optimiert, um die notwendige Infrastruktur (Datenbank und LLM) während des Laufs bereitzustellen.


### PR DESCRIPTION
This change updates the LLM model matrix in the integration test workflow and the project roadmap. It replaces the cloud-based Gemma 4 31B model with the more resource-efficient edge variant 'e4b'. The 'e2b' variant was already included in the configuration. Additionally, it improves repository hygiene by adding Python cache files to .gitignore.

Fixes #71

---
*PR created automatically by Jules for task [5944777598866753405](https://jules.google.com/task/5944777598866753405) started by @chatelao*